### PR TITLE
Configure build fix for all Non-Linux OSes, fixed compilation errors for test suite, feature addition.

### DIFF
--- a/c-posix.c
+++ b/c-posix.c
@@ -4540,6 +4540,14 @@ void create_c() {
 #else
   GDFLT("CLOCAL", 0);
 #endif
+
+#ifdef CRTSCTS
+ GCST("CRTSCTS", CRTSCTS);
+#else
+  GDFLT("CRTSCTS", 0);
+#endif
+
+
 #ifdef CLOCK_REALTIME
   /* Generate the value of CLOCK_REALTIME with a cast to int,
      as the GCST uses printf's %d to print it. Otherwise, if

--- a/configure
+++ b/configure
@@ -2796,8 +2796,84 @@ UNAME_SYSTEM=`(uname -s) 2>/dev/null`
 UNAME_VERSION=`(uname -v) 2>/dev/null`
 
 echo ${UNAME_SYSTEM} ${UNAME_MACHINE} ${UNAME_RELEASE} ${UNAME_VERSION}
-echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
-cp ./configs/pconfig.Linux ./pconfig.h.in;
+case ${UNAME_SYSTEM} in
+ HP-UX)
+   echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+   case ${UNAME_RELEASE} in
+     B.10.*)
+           echo "making Config"
+           cp ./configs/pconfig.HP-UX10.x ./pconfig.h.in;
+           ;;
+     B.11.*)
+           echo "making Config"
+           # getenv might be called during propagation, and modifies errno.
+           safe_errno=False
+           cp ./configs/pconfig.HP-UX11.00 ./pconfig.h.in;
+           ;;
+     *) echo "Unexpected HP-UX release; using default."
+           cp ./configs/pconfig.Default ./pconfig.h.in;
+           ;;
+   esac;
+   ;;
+ SunOS)
+   echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+   case ${UNAME_RELEASE} in
+     5.1[0-9]) cp ./configs/pconfig.SunOS5.10 ./pconfig.h.in ;;
+     *) cp ./configs/pconfig.SunOS5.6 ./pconfig.h.in ;;
+   esac
+   ;;
+ Linux)
+# .... need to add cases here for different thread and C libraries
+   echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+   cp ./configs/pconfig.Linux ./pconfig.h.in;
+   ;;
+ OSF1)
+   echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+   case `gcc -dumpmachine` in
+      *-*-osf4.0[bc])
+	cp ./configs/pconfig.OSF1-4.0b ./pconfig.h.in;
+	;;
+      *-*-osf4.0[d-z] | *-*-osf4.[1-9]* | *-*-osf5* )
+	cp ./configs/pconfig.OSF1 ./pconfig.h.in;
+	;;
+   esac
+   ;;
+ IRIX*)
+   echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+   cp ./configs/pconfig.IRIX6.x ./pconfig.h.in;
+   ;;
+ AIX)
+   echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_VERSION};
+   case `gcc -dumpmachine` in
+      *-*-aix4*)
+        cp ./configs/pconfig.AIX4.1 ./pconfig.h.in;
+	;;
+      *-*-aix[567]*)
+	cp ./configs/pconfig.AIX5.x ./pconfig.h.in;
+	;;
+   esac
+   ;;
+ UnixWare)
+   echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+   cp ./configs/pconfig.UnixWare ./pconfig.h.in;
+   ;;
+ LynxOS)
+    echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+    cp ./configs/pconfig.LynxOS ./pconfig.h.in;
+    ;;
+ FreeBSD)
+    echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+    cp ./configs/pconfig.FreeBSD ./pconfig.h.in;
+    ;;
+ Darwin)
+    echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+    cp ./configs/pconfig.Darwin ./pconfig.h.in;
+    ;;
+ *)
+   echo "No Configuration for ${UNAME_SYSTEM}. Using default.";
+   cp ./configs/pconfig.Default ./pconfig.h.in;
+   ;;
+esac;
 
 if test "x$safe_errno" = "xTrue" ; then
   safe_errno_msg="safe"

--- a/configure.in
+++ b/configure.in
@@ -91,8 +91,84 @@ UNAME_SYSTEM=`(uname -s) 2>/dev/null`
 UNAME_VERSION=`(uname -v) 2>/dev/null`
 
 echo ${UNAME_SYSTEM} ${UNAME_MACHINE} ${UNAME_RELEASE} ${UNAME_VERSION}
-echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
-cp ./configs/pconfig.Linux ./pconfig.h.in;
+case ${UNAME_SYSTEM} in
+ HP-UX)
+   echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+   case ${UNAME_RELEASE} in
+     B.10.*)
+           echo "making Config"
+           cp ./configs/pconfig.HP-UX10.x ./pconfig.h.in;
+           ;;
+     B.11.*)
+           echo "making Config"
+           # getenv might be called during propagation, and modifies errno.
+           safe_errno=False
+           cp ./configs/pconfig.HP-UX11.00 ./pconfig.h.in;
+           ;;
+     *) echo "Unexpected HP-UX release; using default."
+           cp ./configs/pconfig.Default ./pconfig.h.in;
+           ;;
+   esac;
+   ;;
+ SunOS)
+   echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+   case ${UNAME_RELEASE} in
+     5.1[0-9]) cp ./configs/pconfig.SunOS5.10 ./pconfig.h.in ;;
+     *) cp ./configs/pconfig.SunOS5.6 ./pconfig.h.in ;;
+   esac
+   ;;
+ Linux)
+# .... need to add cases here for different thread and C libraries
+   echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+   cp ./configs/pconfig.Linux ./pconfig.h.in;
+   ;;
+ OSF1)
+   echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+   case `gcc -dumpmachine` in
+      *-*-osf4.0[bc])
+	cp ./configs/pconfig.OSF1-4.0b ./pconfig.h.in;
+	;;
+      *-*-osf4.0[d-z] | *-*-osf4.[1-9]* | *-*-osf5* )
+	cp ./configs/pconfig.OSF1 ./pconfig.h.in;
+	;;
+   esac
+   ;;
+ IRIX*)
+   echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+   cp ./configs/pconfig.IRIX6.x ./pconfig.h.in;
+   ;;
+ AIX)
+   echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_VERSION};
+   case `gcc -dumpmachine` in
+      *-*-aix4*)
+        cp ./configs/pconfig.AIX4.1 ./pconfig.h.in;
+	;;
+      *-*-aix[567]*)
+	cp ./configs/pconfig.AIX5.x ./pconfig.h.in;
+	;;
+   esac
+   ;;
+ UnixWare)
+   echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+   cp ./configs/pconfig.UnixWare ./pconfig.h.in;
+   ;;
+ LynxOS)
+    echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+    cp ./configs/pconfig.LynxOS ./pconfig.h.in;
+    ;;
+ FreeBSD)
+    echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+    cp ./configs/pconfig.FreeBSD ./pconfig.h.in;
+    ;;
+ Darwin)
+    echo "Using Configuration for" ${UNAME_SYSTEM} ${UNAME_RELEASE};
+    cp ./configs/pconfig.Darwin ./pconfig.h.in;
+    ;;
+ *)
+   echo "No Configuration for ${UNAME_SYSTEM}. Using default.";
+   cp ./configs/pconfig.Default ./pconfig.h.in;
+   ;;
+esac;
 
 if test "x$safe_errno" = "xTrue" ; then
   safe_errno_msg="safe"

--- a/libsrc/posix-terminal_functions.adb
+++ b/libsrc/posix-terminal_functions.adb
@@ -190,6 +190,7 @@ package body POSIX.Terminal_Functions is
       Perform_Output_Processing => OPOST,
       --  Control_Modes
       Ignore_Modem_Status => CLOCAL,
+      CRTSCTS_Hardware_Flow_Control => CRTSCTS,
       Enable_Receiver => CREAD,
       Send_Two_Stop_Bits => CSTOPB,
       Hang_Up_On_Last_Close => HUPCL,

--- a/libsrc/posix-terminal_functions.ads
+++ b/libsrc/posix-terminal_functions.ads
@@ -69,7 +69,7 @@ package POSIX.Terminal_Functions is
       --  Subtype Output_Modes :
        Perform_Output_Processing,
       --  Subtype Control_Modes :
-       Ignore_Modem_Status, Enable_Receiver, Send_Two_Stop_Bits,
+       Ignore_Modem_Status, CRTSCTS_Hardware_Flow_Control, Enable_Receiver, Send_Two_Stop_Bits,
        Hang_Up_On_Last_Close, Parity_Enable, Odd_Parity,
       --  Subtype Local_Modes:
        Echo, Echo_Erase, Echo_Kill, Echo_LF, Canonical_Input,

--- a/tests/p030300a.adb
+++ b/tests/p030300a.adb
@@ -265,7 +265,7 @@ package body p030300a is
 begin
    Add_All_Signals (All_Signal_Mask);
 
-   for Sig in Realtime_Signal loop
+   for Sig in Realtime_Signal'RANGE loop
       Required_Default_Action (Sig) := Termination;
    end loop;
 

--- a/tests/test_parameters.adb
+++ b/tests/test_parameters.adb
@@ -200,7 +200,7 @@ package body Test_Parameters is
       when SIGUSR1 | SIGUSR2 | SIGINT
         |  5 --  SIGTRAP
         | 26 --  SIGVTALRM
-        | 31 --  SIGUNUSED
+--      | 31 --  SIGUNUSED  -- SIGUSR2 IS 31, there is no real SIGUNUSED, was only for backwards compat.
          => return True;
 --! #     elsif SunOS then
 --! --  The following are correct values for gnat 3.12


### PR DESCRIPTION
I have done separate commits, so hopefully you can pick and choose.  

This first is the Autoconf build system has been partially broken since mid-march.  On commit 4c72dea521a10e084abae9a865c50c169961745d a bug was introduced into the configure scripts that simply copied the Linux version of the pconfig.h.in file as default, regardless of what host OS was detected.  This causes errors (macro code hiding/view issues) on MacOS which error the build very quickly.  I simply reverted the simple change for files "configure & configure.in" to the previous commit (e9113eecce960caae7ec11158d4b07325cded88b).  There have been not other changes since then so this seems simple enough get back on track.

The second fix is an error in tests/test_parameters.adb in the case statement for signals, the comment says the same info, but basically the value of 31 is also used in MacOS (at least) for SIGUSR2...so it conflicts, I just removed the specific value of 31 in the case statement.

The third is a test case warning, not an error, but was a NULL ranged NO-OP loop for looping through the Signals data type, defining default termination behavior, I simply added the 'RANGE to it so the loop did something.  If this was a purposeful neuter I didn't see that as obvious but it can of course be commented out, I assumed the warning about skipping the operation was not the intended behavior. 

The fourth and final is actually a feature-add (my main reason for doing this pull request).  I do realize this could be somewhat controversial as this additional terminal option that isn't strictly in the Ada POSIX interface specification (At least the copy I have from 1998 doesn't list it).  And that is the terminal serial hardware flow control CRTSCTS option.  I have used this on MacOS and I hope I added it correctly where Linux and other UNIXes will work correctly as well (but full disclosure, it's tested ONLY under MacOS, right now).

I'm using your florist library to interface with a voice modem (using the Hayes AT command set) on MacOS and without hardware flow control, it's absolutely unusable for streaming and large command transfer/output.  So I require this option to make things work correctly, because of things like Andriod and Arduino I think CRTSCTS is now a critical option and should be added as "standard" given it's now present in all modern UNIXes and is very important to serial operation.

I'm open to help in improving or changing these, if anyone has a suggestion.  Otherwise, it does work for MacOS now and that's all I know.