### PR TITLE
configure: Avoid C89-only language features

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -254,14 +254,14 @@ AC_DEFUN(AC_POSIX_COMP_OVERLAY,
 AC_MSG_CHECKING(for struct $1 component $2 overlaying $3)
 AC_CACHE_VAL(ac_cv_comp_$2,
 AC_TRY_RUN([#include "confsrc/pconfig.h"
-main()
+int main(void)
 {
   struct $1 x;
   if (&x.$2 == &x.$3) {
     fprintf(stderr,"$2 overlays $3...");
-    exit (1);
+    return 1;
   } else {
-    exit (0);
+    return 0;
   }
 }], eval "ac_cv_comp_$2=yes",
 eval "ac_cv_comp_$2=no", eval "ac_cv_comp_$2=nu"))dnl

--- a/configure
+++ b/configure
@@ -4365,14 +4365,14 @@ fi
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include "confsrc/pconfig.h"
-main()
+int main(void)
 {
   struct sigaction x;
   if (&x.sa_sigaction == &x.sa_handler) {
     fprintf(stderr,"sa_sigaction overlays sa_handler...");
-    exit (1);
+    return 1;
   } else {
-    exit (0);
+    return 0;
   }
 }
 _ACEOF


### PR DESCRIPTION
Avoid an implicit int for main and calls to the undeclared exit function.  Improves compatibility with future compilers which no longer support these C89 language features by default.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
