### PR TITLE
Fixes for macOS Sequoia build problems, some tests still stalling out.

### DIFF
--- a/c-posix.c
+++ b/c-posix.c
@@ -53,6 +53,12 @@
 
  */
 
+#ifdef __APPLE__
+  #define _DARWIN_C_SOURCE
+  #define HAVE_struct_ip_opts
+  //#include <sys/socket.h>
+#endif
+
 #include "confsrc/pconfig.h"
 #include <ctype.h>
 #include <errno.h>
@@ -5205,10 +5211,8 @@ void create_c() {
        is reserved by the Ada runtime system.
  */
 
-#if defined(__APPLE__)
-# define BADSIG 0
-#else
-# define BADSIG (-1)
+#if !defined(__APPLE__)
+  # define BADSIG (-1)
 #endif
 {sigset_t set;
   int sig;

--- a/libsrc/threads/posix-signals.ads
+++ b/libsrc/threads/posix-signals.ads
@@ -92,6 +92,8 @@ package POSIX.Signals is
    SIGUSR1                    : constant Signal := POSIX.C.SIGUSR1;
    Signal_User_2,
    SIGUSR2                    : constant Signal := POSIX.C.SIGUSR2;
+   Signal_Unused,
+   SIGUNUSED                   : constant Signal := 0;
 
    --  Standard Signals (job control)
 
@@ -115,8 +117,17 @@ package POSIX.Signals is
    Signal_Out_Of_Band_Data,
    SIGURG                     : constant Signal := POSIX.C.SIGURG;
 
+   pragma Warnings (Off, "null range");
+   --  This is for MacOS/BSD support, since SIGRTMAX &
+   --  SIGRTMIN are not present on the platform.  This forms
+   --  a null range, which is acceptable for a non-present feature.
+   --  Due to some compilation arguments, warnings treated as errors,
+   --  means this was a critical stop.
+
    subtype Realtime_Signal is Signal range
      Signal (POSIX.C.SIGRTMIN) .. POSIX.C.SIGRTMAX;
+
+   pragma Warnings (On, "null range");
 
    --  Signal sets
 

--- a/tests/test_parameters.adb
+++ b/tests/test_parameters.adb
@@ -200,7 +200,7 @@ package body Test_Parameters is
       when SIGUSR1 | SIGUSR2 | SIGINT
         |  5 --  SIGTRAP
         | 26 --  SIGVTALRM
-        | 31 --  SIGUNUSED
+        | SIGUNUSED
          => return True;
 --! #     elsif SunOS then
 --! --  The following are correct values for gnat 3.12


### PR DESCRIPTION
### Summary of Fixes
This is a series of small fixes to remedy the build system errors found on MacOS Sequoia.  

Most of them were basic C macro visibility issues, one was improper removal of the an old guard, one was an incorrect, re-used, signal value that was fixed by just defining the unused signal by name with a value of 0 (if you can think of a better value, please update that), and lastly struct ip_opts was incorrectly marked as missing in MacOS, so it was redefined by forist source. The fix was to override florist source to allow native MacOS definition of struct ip_opts to be used by enabling HAVE_struct_ip_opts. 

There were no new compilation bugs on the source files themselves.  Everything here is really an alteration to the build system.  Too many test failures to really know how it's operating.  I may eventually look into it but the first couple errors are actually real definitions that honestly differ from the IEEE 1003.5 documentation and so are valid failures due to real differences in Darwin kernel source.

**These fixes were not tested again another OS, so that needs to be done to ensure they are clean and apply to MacOS only.**

### Build problems included:

_MacOS - Test Parameters.adb:_
**SIGUSR2** = 31 so created a real **SIGUNUSED** Variable = 0 instead and used that.

_MacOS - posix-signals.ads_
Created **SIGUNUSED**  := 0;

I put back a previously existing PRAGMA warning off that protected a invalid range definition for Realtime_Signal, This should have never been removed, unknown why MacOS guards were altered?

_MacOS - c-posix.c_
Build errors basically due to missing some C macro definitions that only appear when **DARWIN_C_SOURCE** is defined. Used  __APPLE__ Macro to enable these other needed macros or even make them visible.

**ip_opts** struct was incorrectly detected on MacOS as missing.  Forcibly enabled HAVE_struct_ip_opts just for __APPLE__ to fix this, didn't see a better way.

Thanks!